### PR TITLE
Get build script working on CentOS

### DIFF
--- a/do-update-makerpm.sh
+++ b/do-update-makerpm.sh
@@ -170,6 +170,12 @@ if [[ -e /etc/os-release ]]; then
 	if [[ "$ID" == "sle_hpc" ]]; then
 		ID="sles"
 	fi
+	if [[ $ID == "centos" ]]; then
+		ID="rhel"
+		VERSION_ID=$(awk '{print $4;}' /etc/centos-release)
+		VERSION_ID_BUILD=${VERSION_ID##*.}
+		VERSION_ID=${VERSION_ID%.*}
+	fi
 else
 	echo "File /etc/os-release is missing."
 	exit 1


### PR DESCRIPTION
do-update-makerpm.sh was failing to work on CentOS 7.8.xxx
systems, it would just quit and return to shell prompt
after the "Setting up RPM build area" message.

This patch allows it to correctly choose a compat_dir
and successfully build on CentOS.

Signed-off-by: Douglas Miller <doug.miller@cornelisnetworks.com>